### PR TITLE
Remove ModTools integration

### DIFF
--- a/MoveIt/GUI/UIDebugPanel.cs
+++ b/MoveIt/GUI/UIDebugPanel.cs
@@ -1,4 +1,4 @@
-﻿using ColossalFramework.Plugins;
+using ColossalFramework.Plugins;
 using ColossalFramework.UI;
 using System;
 using System.Linq;
@@ -10,18 +10,12 @@ namespace MoveIt
     internal class DebugPanel
     {
         internal UIPanel Panel;
-        internal DebugPanel_ModTools ModTools = null;
         private UILabel HoverLarge, HoverSmall, ToolStatus, SelectedLarge, SelectedSmall;
         private InstanceID id, lastId;
 
         internal DebugPanel()
         {
             _initialise();
-
-            if (isModToolsEnabled())
-            {
-                ModTools = new DebugPanel_ModTools(Panel);
-            }
         }
 
         internal void Visible(bool show)
@@ -116,7 +110,6 @@ namespace MoveIt
                 BuildingInfo info = BuildingManager.instance.m_buildings.m_buffer[id.Building].Info;
                 HoverLarge.text = $"B:{id.Building}  {info.name}";
                 HoverSmall.text = $"{info.GetType()} ({info.GetAI().GetType()})\n{info.m_class.name}\n({info.m_class.m_service}.{info.m_class.m_subService})";
-                if (isModToolsEnabled()) ModTools.Id = id;
             }
             else if (id.Prop > 0)
             {
@@ -125,43 +118,33 @@ namespace MoveIt
                 if (info.m_isDecal) type = "D";
                 HoverLarge.text = $"{type}:{id.Prop}  {info.name}";
                 HoverSmall.text = $"{info.GetType()}\n{info.m_class.name}";
-                if (isModToolsEnabled()) ModTools.Id = id;
             }
             else if (id.NetLane > 0)
             {
                 IInfo info = MoveItTool.PO.GetProcObj(id.NetLane).Info;
                 HoverLarge.text = $"{id.NetLane}: {info.Name}";
                 HoverSmall.text = $"\n";
-                if (isModToolsEnabled()) ModTools.Id = id;
             }
             else if (id.Tree > 0)
             {
                 TreeInfo info = TreeManager.instance.m_trees.m_buffer[id.Tree].Info;
                 HoverLarge.text = $"T:{id.Tree}  {info.name}";
                 HoverSmall.text = $"{info.GetType()}\n{info.m_class.name}";
-                if (isModToolsEnabled()) ModTools.Id = id;
             }
             else if (id.NetNode > 0)
             {
                 NetInfo info = NetManager.instance.m_nodes.m_buffer[id.NetNode].Info;
                 HoverLarge.text = $"N:{id.NetNode}  {info.name}";
                 HoverSmall.text = $"{info.GetType()} ({info.GetAI().GetType()})\n{info.m_class.name}";
-                if (isModToolsEnabled()) ModTools.Id = id;
             }
             else if (id.NetSegment > 0)
             {
                 NetInfo info = NetManager.instance.m_segments.m_buffer[id.NetSegment].Info;
                 HoverLarge.text = $"S:{id.NetSegment}  {info.name}";
                 HoverSmall.text = $"{info.GetType()} ({info.GetAI().GetType()})\n{info.m_class.name}";
-                if (isModToolsEnabled()) ModTools.Id = id;
             }
 
             lastId = id;
-        }
-
-        internal static bool isModToolsEnabled()
-        {
-            return PluginManager.instance.GetPluginsInfo().Any(mod => (mod.publishedFileID.AsUInt64 == 450877484uL || mod.name.Contains("ModTools")) && mod.isEnabled);
         }
 
         private void _initialise()
@@ -219,165 +202,6 @@ namespace MoveIt
             SelectedSmall.clipChildren = true;
             SelectedSmall.useDropShadow = true;
             SelectedSmall.dropShadowOffset = new Vector2(1, -1);
-        }
-    }
-
-
-    internal class DebugPanel_ModTools
-    {
-        internal InstanceID Id { get; set; }
-        internal UIPanel Parent { get; set; }
-        internal UIButton btn;
-        private readonly object ModTools, SceneExplorer;
-        private readonly Type tModTools, tSceneExplorer, tReferenceChain;
-        private readonly BindingFlags flags = BindingFlags.Public | BindingFlags.Instance;
-        private readonly object rcBuildings, rcProps, rcTrees, rcNodes, rcSegments;
-
-        internal DebugPanel_ModTools(UIPanel parent)
-        {
-            try
-            {
-                Assembly mtAssembly = null;
-                foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
-                {
-                    if (assembly.FullName.Length >= 8 && assembly.FullName.Substring(0, 8) == "ModTools")
-                    {
-                        mtAssembly = assembly;
-                        break;
-                    }
-                }
-                if (mtAssembly == null)
-                {
-                    return;
-                }
-
-                tModTools = mtAssembly.GetType("ModTools.MainWindow");
-                tSceneExplorer = mtAssembly.GetType("ModTools.Explorer.SceneExplorer");
-                tReferenceChain = mtAssembly.GetType("ModTools.Explorer.ReferenceChain");
-
-                ModTools = tModTools.GetProperty("Instance", BindingFlags.Public | BindingFlags.Static).GetValue(null, null);
-                SceneExplorer = tModTools.GetProperty("SceneExplorer", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(ModTools, null);
-
-                //Debug.Log($"\ntModTools:{tModTools}, tSceneExplorer:{tSceneExplorer}, tReferenceChain:{tReferenceChain}");
-                //Debug.Log($"\n{ModTools} ({ModTools.GetType()})\n{SceneExplorer} <{SceneExplorer.GetType()}>");
-                //Debug.Log($"\nFields:{tModTools.GetFields().Length}, Props:{tModTools.GetProperties().Length}, Methods:{tModTools.GetMethods().Length}");
-
-                rcBuildings = Activator.CreateInstance(tReferenceChain);
-                rcBuildings = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(GameObject) }, null).Invoke(rcBuildings, new object[] { BuildingManager.instance.gameObject });
-                rcBuildings = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(BuildingManager) }, null).Invoke(rcBuildings, new object[] { BuildingManager.instance });
-                rcBuildings = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(FieldInfo) }, null).Invoke(rcBuildings, new object[] { typeof(BuildingManager).GetField("m_buildings") });
-                rcBuildings = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(FieldInfo) }, null).Invoke(rcBuildings, new object[] { typeof(Array16<Building>).GetField("m_buffer") });
-                //Debug.Log($"rcBuildings:{rcBuildings}");
-
-                rcProps = Activator.CreateInstance(tReferenceChain);
-                rcProps = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(GameObject) }, null).Invoke(rcProps, new object[] { PropManager.instance.gameObject });
-                rcProps = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(PropManager) }, null).Invoke(rcProps, new object[] { PropManager.instance });
-                rcProps = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(FieldInfo) }, null).Invoke(rcProps, new object[] { typeof(PropManager).GetField("m_props") });
-                rcProps = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(FieldInfo) }, null).Invoke(rcProps, new object[] { typeof(Array16<PropInstance>).GetField("m_buffer") });
-                //Debug.Log($"rcProps:{rcProps}");
-
-                rcTrees = Activator.CreateInstance(tReferenceChain);
-                rcTrees = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(GameObject) }, null).Invoke(rcTrees, new object[] { TreeManager.instance.gameObject });
-                rcTrees = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(TreeManager) }, null).Invoke(rcTrees, new object[] { TreeManager.instance });
-                rcTrees = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(FieldInfo) }, null).Invoke(rcTrees, new object[] { typeof(TreeManager).GetField("m_trees") });
-                rcTrees = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(FieldInfo) }, null).Invoke(rcTrees, new object[] { typeof(Array32<TreeInstance>).GetField("m_buffer") });
-                //Debug.Log($"rcTrees:{rcTrees}");
-
-                rcNodes = Activator.CreateInstance(tReferenceChain);
-                rcNodes = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(GameObject) }, null).Invoke(rcNodes, new object[] { NetManager.instance.gameObject });
-                rcNodes = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(NetManager) }, null).Invoke(rcNodes, new object[] { NetManager.instance });
-                rcSegments = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(FieldInfo) }, null).Invoke(rcNodes, new object[] { typeof(NetManager).GetField("m_segments") });
-                rcSegments = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(FieldInfo) }, null).Invoke(rcSegments, new object[] { typeof(Array16<NetSegment>).GetField("m_buffer") });
-                rcNodes = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(FieldInfo) }, null).Invoke(rcNodes, new object[] { typeof(NetManager).GetField("m_nodes") });
-                rcNodes = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(FieldInfo) }, null).Invoke(rcNodes, new object[] { typeof(Array16<NetNode>).GetField("m_buffer") });
-                //Debug.Log($"rcNodes:{rcNodes}\nrcSegments:{rcSegments}");
-
-                //rcPO = MoveItTool.PO.GetReferenceChain(tReferenceChain);
-            }
-            catch (ReflectionTypeLoadException)
-            {
-                SceneExplorer = null;
-                Debug.Log($"MoveIt failed to integrate ModTools (ReflectionTypeLoadException)");
-            }
-            catch (NullReferenceException)
-            {
-                SceneExplorer = null;
-                Debug.Log($"MoveIt failed to integrate ModTools (NullReferenceException)");
-            }
-
-            if (SceneExplorer == null)
-            {
-                return;
-            }
-
-            Id = InstanceID.Empty;
-            Parent = parent;
-            btn = parent.AddUIComponent<UIButton>();
-            btn.name = "MoveIt_ToModTools";
-            btn.text = ">";
-            btn.textScale = 0.7f;
-            btn.tooltip = "Open in ModTools Scene Explorer";
-            btn.size = new Vector2(20, 20);
-            btn.textPadding = new RectOffset(1, 0, 5, 1);
-            btn.relativePosition = new Vector3(parent.width - 24, 22);
-            btn.eventClicked += _toModTools;
-
-            btn.atlas = ResourceLoader.GetAtlas("Ingame");
-            btn.normalBgSprite = "OptionBase";
-            btn.hoveredBgSprite = "OptionBaseHovered";
-            btn.pressedBgSprite = "OptionBasePressed";
-            btn.disabledBgSprite = "OptionBaseDisabled";
-        }
-
-        private void _toModTools(UIComponent c, UIMouseEventParameter p)
-        {
-            if (SceneExplorer == null)
-            {
-                return;
-            }
-
-            try
-            {
-                object rc = null;
-                Type[] t = new Type[] { tReferenceChain };
-
-                if (Id.Building > 0)
-                {
-                    rc = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(ushort) }, null).Invoke(rcBuildings, new object[] { Id.Building });
-                    //Debug.Log(tSceneExplorer.GetMethod("ExpandFromRefChain", flags, null, t, null).Invoke(SceneExplorer, new object[] { rc }));
-                }
-                else if (Id.Prop > 0)
-                {
-                    rc = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(ushort) }, null).Invoke(rcProps, new object[] { Id.Prop });
-                    //tSceneExplorer.GetMethod("ExpandFromRefChain", flags, null, t, null).Invoke(SceneExplorer, new object[] { rc });
-                }
-                else if (Id.Tree > 0)
-                {
-                    rc = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(int) }, null).Invoke(rcTrees, new object[] { (int)Id.Tree });
-                    //tSceneExplorer.GetMethod("ExpandFromRefChain", flags, null, t, null).Invoke(SceneExplorer, new object[] { rc });
-                }
-                else if (Id.NetNode > 0)
-                {
-                    rc = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(ushort) }, null).Invoke(rcNodes, new object[] { Id.NetNode });
-                    //tSceneExplorer.GetMethod("ExpandFromRefChain", flags, null, t, null).Invoke(SceneExplorer, new object[] { rc });
-                }
-                else if (Id.NetSegment > 0)
-                {
-                    rc = tReferenceChain.GetMethod("Add", flags, null, new Type[] { typeof(ushort) }, null).Invoke(rcSegments, new object[] { Id.NetSegment });
-                    //tSceneExplorer.GetMethod("ExpandFromRefChain", flags, null, t, null).Invoke(SceneExplorer, new object[] { rc });
-                }
-
-                tSceneExplorer.GetMethod("Show").Invoke(SceneExplorer, new[] { rc });
-                //tSceneExplorer.GetProperty("visible", BindingFlags.Public | BindingFlags.Instance).SetValue(SceneExplorer, true, null);
-            }
-            catch (ReflectionTypeLoadException)
-            {
-                Debug.Log($"MoveIt failed to call ModTools (ReflectionTypeLoadException)");
-            }
-            catch (NullReferenceException)
-            {
-                Debug.Log($"MoveIt failed to call ModTools (NullReferenceException)");
-            }
         }
     }
 }


### PR DESCRIPTION
ModTools 3.2.0 is going to be released soon. It now has its own tool that allows to show any vehicle/prop/building/node/etc. in SceneExplorer. And of course that release is going to be incompatible with MoveIt again :) Thus, we better just remove the integration from here.