### PR TITLE
Triggers a RoadCheckNeeded after a building is moved such that you'll…

### DIFF
--- a/MoveIt/Actions/TransformAction.cs
+++ b/MoveIt/Actions/TransformAction.cs
@@ -101,6 +101,10 @@ namespace MoveIt
                     if (autoCurve && state.instance is MoveableNode node)
                     {
                         node.AutoCurve(segmentCurve);
+                    } 
+                    else if (state.instance is MoveableBuilding building)
+                    {
+                        BuildingManager.instance.RoadCheckNeeded(building.id.Building);
                     }
                 }
             }


### PR DESCRIPTION
… get a "no road access" icon if you moved a building too far away from the road.
This currently works for ploppables only, since only they implement the CheckRoadAccess method.
But I'm working on a separate mod that will also make the same available for Growables.