### PR TITLE
Paste map is null should restore documentation

### DIFF
--- a/MoveItIntegration/Integration.cs
+++ b/MoveItIntegration/Integration.cs
@@ -51,7 +51,8 @@ namespace MoveItIntegration
         /// <param name="record">data returned by <see cref="Copy(InstanceID)"/></param>
         /// <param name="map">a dictionary of source instance ID to target instance ID.
         /// this maps all the nodes, segments and lanes. 
-        /// please contact mod owner if you need buildings, props, etc to be mapped as well</param>
+        /// please contact mod owner if you need buildings, props, etc to be mapped as well.
+        /// If this is null the record given will be restored</param>
         public abstract void Paste(InstanceID targetInstanceID, object record, Dictionary<InstanceID, InstanceID> map);
 
         /// <summary>Paste object data that has been mirrored, with segment ends needing reversed</summary>


### PR DESCRIPTION
Added extra documentation for cases where paste is called with a null map informing that this should result in the record given being restored.
This is useful for cases where you don't need to remap anything just effectively override it or restore it.
I have discussed this with kianzarrin.