### PR TITLE
Minor changes to reflect new EML API.

### DIFF
--- a/MoveIt/PropInstance.cs
+++ b/MoveIt/PropInstance.cs
@@ -98,7 +98,7 @@ namespace MoveIt
     class EPropWrapper : IProp
     {
         private readonly uint index;
-        private readonly EPropInstance[] Buffer = PropAPI.GetPropBuffer();
+        private readonly EPropInstance[] Buffer = EPropManager.m_props.m_buffer;
 
         public void MoveProp(Vector3 position)
         {

--- a/MoveIt/PropLayer.cs
+++ b/MoveIt/PropLayer.cs
@@ -195,7 +195,7 @@ namespace MoveIt
 
         public EPropsManager()
         {
-            propBuffer = PropAPI.GetPropBuffer();
+            propBuffer = EPropManager.m_props.m_buffer;
         }
 
         public IInfo GetInfo(InstanceID id)


### PR DESCRIPTION
I removed PropAPI::GetPropBuffer(), since all it does is return the buffer to EPropInstance.
Just get the buffer directly.

Your PropInstance and PropLayer does exactly the same things EML.API.PropAPI does, and it's up to you which one you want to use.