### PR TITLE
Also add Tree Anarchy Beta workshop ID to search condition

### DIFF
--- a/MoveIt/MIT_Utilities.cs
+++ b/MoveIt/MIT_Utilities.cs
@@ -308,6 +308,7 @@ namespace MoveIt
         {
             if (!PluginManager.instance.GetPluginsInfo().Any(mod => (
                     mod.publishedFileID.AsUInt64 == 2527486462uL ||
+                    mod.publishedFileID.AsUInt64 == 2584051448uL ||
                     mod.name.StartsWith("TreeAnarchy")
             ) && mod.isEnabled))
             {


### PR DESCRIPTION
Players were complaining that trees could not be raised or lowered when using Tree Anarchy Beta, and this might be the solution?