### PR TITLE
Enable FixedHeight setting for Prop Snapping when using EML

### DIFF
--- a/MoveIt/MIT_Utilities.cs
+++ b/MoveIt/MIT_Utilities.cs
@@ -308,6 +308,7 @@ namespace MoveIt
         {
             if (!PluginManager.instance.GetPluginsInfo().Any(mod => (
                     mod.publishedFileID.AsUInt64 == 2527486462uL ||
+                    mod.publishedFileID.AsUInt64 == 2584051448uL ||
                     mod.name.StartsWith("TreeAnarchy")
             ) && mod.isEnabled))
             {

--- a/MoveIt/Moveable/MoveableProp.cs
+++ b/MoveIt/Moveable/MoveableProp.cs
@@ -149,9 +149,9 @@ namespace MoveIt
                         y = terrainHeight;
                     }
                 }
-            } else {
-                y = newPosition.y;
+                return y;
             }
+            return newPosition.y;
 
             //Log.Debug($"{path}\nstate:{state.terrainHeight} tH-state:{terrainHeight - state.terrainHeight}, yTO:{yTerrainOffset}\n" +
             //    $"ft:{followTerrain}, ts:{MoveItTool.treeSnapping}, fh:{trees[treeID].FixedHeight}, dh:{deltaHeight}\n" +
@@ -159,8 +159,6 @@ namespace MoveIt
             //    $"ADJUST - adjY:{y}, newY:{newPosition.y}, diff:{y - newPosition.y}\n" +
             //    $"TOTAL  - adjY:{y}, oldY:{position.y}, diff:{y - position.y}\n" +
             //    $"HEIGHT - adjY:{y}, terrainHeight:{terrainHeight}, diff:{y - terrainHeight}");
-
-            return y;
         }
 
         public override void Move(Vector3 location, float angle)

--- a/MoveIt/Moveable/MoveableProp.cs
+++ b/MoveIt/Moveable/MoveableProp.cs
@@ -125,29 +125,32 @@ namespace MoveIt
 
             float terrainHeight = Singleton<TerrainManager>.instance.SampleDetailHeight(newPosition);
 
-            //string path = "";
-            if (!manager.GetSnappingState()) {
-                //path += "A";
-                y = terrainHeight;
-            } else if (manager.GetFixedHeight(id)) { // If it's already fixed height, handle followTerrain
-                // If the state is being cloned, don't use the terrain-height offset
-                //path += "B";
-                y = newPosition.y + (isClone ? 0 : yTerrainOffset);
-                if (followTerrain) {
-                    //path += "1";
-                    y += terrainHeight - state.terrainHeight;
-                }
-            } else { // Snapping is on and it is not fixed height yet
-                //path += "C";
-                if (deltaHeight != 0) {
-                    //path += "1";
-                    manager.SetFixedHeight(id, true);
-                    y = terrainHeight + deltaHeight;
-                    yTerrainOffset = terrainHeight - state.terrainHeight;
-                } else {
-                    //path += "2";
+            if(PropLayer.isEMLInstalled()) {
+                if (!manager.GetSnappingState()) {
+                    //path += "A";
                     y = terrainHeight;
+                } else if (manager.GetFixedHeight(id)) { // If it's already fixed height, handle followTerrain
+                                                         // If the state is being cloned, don't use the terrain-height offset
+                                                         //path += "B";
+                    y = newPosition.y + (isClone ? 0 : yTerrainOffset);
+                    if (followTerrain) {
+                        //path += "1";
+                        y += terrainHeight - state.terrainHeight;
+                    }
+                } else { // Snapping is on and it is not fixed height yet
+                         //path += "C";
+                    if (deltaHeight != 0) {
+                        //path += "1";
+                        manager.SetFixedHeight(id, true);
+                        y = terrainHeight + deltaHeight;
+                        yTerrainOffset = terrainHeight - state.terrainHeight;
+                    } else {
+                        //path += "2";
+                        y = terrainHeight;
+                    }
                 }
+            } else {
+                y = newPosition.y;
             }
 
             //Log.Debug($"{path}\nstate:{state.terrainHeight} tH-state:{terrainHeight - state.terrainHeight}, yTO:{yTerrainOffset}\n" +

--- a/MoveIt/PropLayer.cs
+++ b/MoveIt/PropLayer.cs
@@ -68,10 +68,12 @@ namespace MoveIt
         void UpdateProps(float minX, float minZ, float maxX, float maxZ);
         void TouchProps();
         bool CreateProp(out uint clone, PropInfo info, Vector3 position, float angle, bool single);
+        bool GetFixedHeight(InstanceID id);
         void SetFixedHeight(InstanceID id, bool fixedHeight);
         InstanceID StepOver(uint id);
         void RaycastHoverInstance(ref int i, ref int j, ref StepOver stepOver, ref Segment3 ray, ref float smallestDist, ref InstanceID id);
         void GetMarqueeList(ref int i, ref int j, ref InstanceID id, ref Quad3 m_selection, ref HashSet<Instance> list);
+        bool GetSnappingState();
     }
 
     class PropsManager : IPropsWrapper
@@ -126,6 +128,8 @@ namespace MoveIt
             clone = tempId;
             return result;
         }
+
+        public bool GetFixedHeight(InstanceID id) => propBuffer[id.Prop].FixedHeight;
 
         public void SetFixedHeight(InstanceID id, bool fixedHeight)
         {
@@ -201,6 +205,7 @@ namespace MoveIt
                 }
             }
         }
+        public bool GetSnappingState() => false;
     }
 
     // Extended Managers Library support
@@ -251,6 +256,8 @@ namespace MoveIt
         {
             return PropAPI.Wrapper.CreateProp(out clone, info, position, angle, single);
         }
+
+        public bool GetFixedHeight(InstanceID id) => PropAPI.Wrapper.GetFixedHeight(id);
 
         public void SetFixedHeight(InstanceID id, bool fixedHeight)
         {
@@ -307,5 +314,7 @@ namespace MoveIt
                 }
             }
         }
+
+        public bool GetSnappingState() => PropAPI.Wrapper.IsSnappingEnabled;
     }
 }


### PR DESCRIPTION
In this pull request, the Tree Anarchy ID changes still made it in, and I don't know how to exclude it (Please ignore this patch).

As for Prop Snapping, the codes to enable it in MoveableProp is exactly like what's done in MoveableTree. I had to add a few more API changes, so this will be a painful upgrade, but this was necessary for Prop Snapping to function correctly.

The changes are in PropLayer, where I mapped a few more functions regarding Prop Snapping state, and GetFixedHeight.
The other changes are in MoveableProp, and the changes are exactly like MoveableTree.