### PR TITLE
Fixes offsetted height in Set Position Tool

### DIFF
--- a/MoveIt/Moveable/MoveableNode.cs
+++ b/MoveIt/Moveable/MoveableNode.cs
@@ -550,6 +550,7 @@ namespace MoveIt
             {
                 node.m_bounds = new Bounds(node.m_position, new Vector3(16f, 0f, 16f));
             }
+            node.m_bounds.center = node.m_position;
 
             return node.m_bounds;
         }


### PR DESCRIPTION
Fixes the issue with the Set Position Tool where all node heights (except end nodes) were offsetted by a value the size of m_bounds.Center or m_bounds.Extents. Typing 60 meters height would result in 62.5 height for basic roads, 39.45 for quays. Making it very hard to work with when building close to sea level. With this fix I've had no issues whatsoever after two months of extensive use